### PR TITLE
SciPy: cast maxiter to int for gmres

### DIFF
--- a/transiflow/interface/JaDa.py
+++ b/transiflow/interface/JaDa.py
@@ -136,7 +136,9 @@ class Interface(NumPyInterface.NumPyInterface):
 
             restart = min(maxit, 100)
             maxiter = (maxit - 1) // restart + 1
-            out[:, i], info = sparse.linalg.gmres(op, x[:, i], restart=restart, maxiter=maxiter, tol=tol, atol=0, M=prec_op)
+            y, info = sparse.linalg.gmres(op, x[:, i], restart=restart, maxiter=maxiter, tol=tol, atol=0, M=prec_op)
+            out[:, i] = op.proj(y)
+
             if info < 0:
                 raise Exception('GMRES returned ' + str(info))
             elif info > 0 and maxit > 1:
@@ -198,7 +200,7 @@ class BorderedInterface(NumPyInterface.NumPyInterface):
             x2 = numpy.append(x[:, i], numpy.zeros(op.Q.shape[1], x.dtype))
             y, info = sparse.linalg.gmres(shifted_bordered_op, x2, restart=restart,
                                           maxiter=maxiter, tol=tol, atol=0, M=prec_op)
-            out[:, i] = y[:-op.Q.shape[1]]
+            out[:, i] = op.proj(y[:-op.Q.shape[1]])
 
             if info < 0:
                 raise Exception('GMRES returned ' + str(info))

--- a/transiflow/interface/SciPy.py
+++ b/transiflow/interface/SciPy.py
@@ -285,7 +285,7 @@ class Interface(BaseInterface):
 
         parameters = self.parameters.get('Iterative Solver', {})
         restart = parameters.get('Restart', 100)
-        maxiter = parameters.get('Maximum Iterations', 1000) / restart
+        maxiter = parameters.get('Maximum Iterations', 1000) // restart
         tol = parameters.get('Convergence Tolerance', 1e-6)
 
         y, info = linalg.gmres(A, x, restart=restart, maxiter=maxiter,


### PR DESCRIPTION
`maxiter` being a float will cause `test_Scipy.py` to fail:

```
>       for iteration in range(maxiter):
E       TypeError: 'float' object cannot be interpreted as an integer

/usr/lib/python3.11/site-packages/scipy/sparse/linalg/_isolve/iterative.py:764: TypeError
```

Casting to `int` fixes the issue.

tested with python 3.11, scipy 1.12.0